### PR TITLE
Book reading state sync fix

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -50,6 +50,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/api/v3/content/checkforchanges, roles: PUBLIC_ACCESS }
         - { path: ^/login, roles: PUBLIC_ACCESS }
         - { path: ^/logout, roles: ROLE_USER }
         - { path: ^/, roles: ROLE_USER }

--- a/migrations/Version20241121135658.php
+++ b/migrations/Version20241121135658.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241121135658 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add device_id to kobo device';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kobo_device ADD device_id VARCHAR(255) DEFAULT NULL');
+        $this->addSql('CREATE INDEX kobo_device_id ON kobo_device (device_id);');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX kobo_device_id ON kobo_device;');
+        $this->addSql('ALTER TABLE kobo_device DROP device_id;');
+    }
+}

--- a/migrations/Version20241121142239.php
+++ b/migrations/Version20241121142239.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241121142239 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add model to kobo device';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kobo_device ADD model VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kobo_device DROP model');
+    }
+}

--- a/src/Controller/Kobo/KoboAnalyticsController.php
+++ b/src/Controller/Kobo/KoboAnalyticsController.php
@@ -2,8 +2,10 @@
 
 namespace App\Controller\Kobo;
 
+use App\Entity\KoboDevice;
 use App\Kobo\Proxy\KoboProxyConfiguration;
 use App\Kobo\Proxy\KoboStoreProxy;
+use App\Repository\KoboDeviceRepository;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -16,8 +18,12 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route('/kobo/{accessKey}', name: 'kobo')]
 class KoboAnalyticsController extends AbstractController
 {
-    public function __construct(protected KoboProxyConfiguration $koboProxyConfiguration, protected KoboStoreProxy $koboStoreProxy, protected LoggerInterface $logger)
-    {
+    public function __construct(
+        protected KoboProxyConfiguration $koboProxyConfiguration,
+        protected KoboStoreProxy $koboStoreProxy,
+        protected KoboDeviceRepository $koboDeviceRepository,
+        protected LoggerInterface $logger,
+    ) {
     }
 
     /**
@@ -46,8 +52,17 @@ class KoboAnalyticsController extends AbstractController
      * @throws GuzzleException
      */
     #[Route('/v1/analytics/event', methods: ['POST'])]
-    public function analyticsEvent(Request $request): Response
+    public function analyticsEvent(Request $request, KoboDevice $kobo): Response
     {
+        // Save the device_id and model
+        if ($request->headers->has(KoboDevice::KOBO_DEVICE_ID_HEADER)) {
+            $kobo->setDeviceId($request->headers->get(KoboDevice::KOBO_DEVICE_ID_HEADER));
+            if ($request->headers->has(KoboDevice::KOBO_DEVICE_MODEL)) {
+                $kobo->setModel($request->headers->get(KoboDevice::KOBO_DEVICE_MODEL));
+            }
+            $this->koboDeviceRepository->save($kobo);
+        }
+
         $content = $request->getContent();
         $json = trim($content) === '' ? [] : (array) json_decode($content, true, 512, JSON_THROW_ON_ERROR);
         $this->logger->debug('Analytics event received', ['body' => $json]);

--- a/src/Controller/Kobo/KoboInitializationController.php
+++ b/src/Controller/Kobo/KoboInitializationController.php
@@ -50,10 +50,11 @@ class KoboInitializationController extends AbstractController
 
         // Image host: https://<domain>
         $jsonData['Resources']['image_host'] = rtrim($this->generateUrl('app_dashboard', [], UrlGenerator::ABSOLUTE_URL), '/');
-
-        // TODO: Use router instead of hard-coding path.
         $jsonData['Resources']['image_url_template'] = $base.'/image/{ImageId}/{width}/{height}/{Quality}/isGreyscale/image.jpg';
         $jsonData['Resources']['image_url_quality_template'] = $base.'/{ImageId}/{width}/{height}/false/image.jpg';
+
+        // Reading services
+        $jsonData['Resources']['reading_services_host'] = rtrim($this->generateUrl('app_dashboard', [], UrlGenerator::ABSOLUTE_URL), '/');
 
         $response = new JsonResponse($jsonData);
         $response->headers->set('kobo-api-token', 'e30=');

--- a/src/Controller/Kobo/ReadServiceCheckForChangesController.php
+++ b/src/Controller/Kobo/ReadServiceCheckForChangesController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Controller\Kobo;
+
+use App\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ReadServiceCheckForChangesController extends AbstractController
+{
+    #[Route('/api/v3/content/checkforchanges', name: 'check_for_changes', methods: ['POST'])]
+    public function checkForChanges(): Response
+    {
+        // If you set "reading_services_host" on your Kobo's config you should point here.
+        // This endpoint tells the kobo that the book reading status has not changed.
+        // If you don't implement it, opening a book on the kobo will reset your progress
+        // to the beginning of the current chapter.
+        return new JsonResponse([]);
+    }
+}

--- a/src/Entity/KoboDevice.php
+++ b/src/Entity/KoboDevice.php
@@ -11,10 +11,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: KoboDeviceRepository::class)]
 #[ORM\UniqueConstraint(name: 'kobo_access_key', columns: ['access_key'])]
+#[ORM\Index(columns: ['device_id'], name: 'kobo_device_id')]
+#[ORM\Index(columns: ['access_key'], name: 'kobo_access_key')]
 #[UniqueEntity(fields: ['accessKey'])]
 class KoboDevice
 {
     use RandomGeneratorTrait;
+    public const KOBO_DEVICE_ID_HEADER = 'X-Kobo-Deviceid';
+    public const KOBO_DEVICE_MODEL = 'X-Kobo-Devicemodel';
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -34,6 +38,11 @@ class KoboDevice
     #[Assert\Regex(pattern: '/^[a-f0-9]+$/', message: 'Need to be Hexadecimal')]
     private ?string $accessKey = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $deviceId = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $model = null;
     /**
      * @var Collection<int, Shelf>
      */
@@ -161,5 +170,29 @@ class KoboDevice
     public function removeShelf(Shelf $shelf): void
     {
         $this->shelves->removeElement($shelf);
+    }
+
+    public function getDeviceId(): ?string
+    {
+        return $this->deviceId;
+    }
+
+    public function setDeviceId(?string $deviceId): self
+    {
+        $this->deviceId = $deviceId;
+
+        return $this;
+    }
+
+    public function getModel(): ?string
+    {
+        return $this->model;
+    }
+
+    public function setModel(?string $model): self
+    {
+        $this->model = $model;
+
+        return $this;
     }
 }

--- a/src/Form/KoboType.php
+++ b/src/Form/KoboType.php
@@ -23,6 +23,16 @@ class KoboType extends AbstractType
         $builder
             ->add('name')
             ->add('accessKey')
+            ->add('deviceId', null, [
+                'label' => 'Device ID',
+                'disabled' => true,
+                'required' => false,
+            ])
+            ->add('model', null, [
+                'label' => 'Model',
+                'disabled' => true,
+                'required' => false,
+            ])
             ->add('forceSync', null, [
                 'label' => 'Force Sync',
                 'required' => false,

--- a/src/Kobo/Response/ReadingStateResponse.php
+++ b/src/Kobo/Response/ReadingStateResponse.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Kobo\Response;
+
+use App\Entity\Book;
+use App\Entity\BookmarkUser;
+use App\Entity\KoboDevice;
+use App\Kobo\SyncToken;
+use App\Service\BookProgressionService;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class ReadingStateResponse
+{
+    public function __construct(
+        protected BookProgressionService $bookProgressionService,
+        protected SerializerInterface $serializer,
+        protected SyncToken $syncToken,
+        protected KoboDevice $kobo,
+        protected Book $book,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function createReadingState(): array
+    {
+        $book = $this->book;
+        $uuid = $book->getUuid();
+
+        $lastModified = $this->syncToken->maxLastModified($book->getUpdated(), $this->syncToken->currentDate, $book->getLastInteraction($this->kobo->getUser())?->getUpdated());
+
+        return [
+            'EntitlementId' => $uuid,
+            'Created' => $this->syncToken->maxLastCreated($book->getCreated(), $this->syncToken->currentDate, $book->getLastInteraction($this->kobo->getUser())?->getCreated()),
+            'LastModified' => $lastModified,
+            'PriorityTimestamp' => $lastModified,
+            'StatusInfo' => [
+                'LastModified' => $lastModified,
+                'Status' => match ($this->isReadingFinished($book)) {
+                    true => SyncResponse::READING_STATUS_FINISHED,
+                    false => SyncResponse::READING_STATUS_IN_PROGRESS,
+                    null => SyncResponse::READING_STATUS_UNREAD,
+                },
+                'TimesStartedReading' => 0,
+            ],
+
+            // "Statistics"=> get_statistics_response(kobo_reading_state.statistics),
+            'CurrentBookmark' => $this->createBookmark($this->kobo->getUser()->getBookmarkForBook($book)),
+        ];
+    }
+
+    /**
+     * @return bool|null Null if we do not now the reading state
+     */
+    private function isReadingFinished(Book $book): ?bool
+    {
+        $progression = $this->bookProgressionService->getProgression($book, $this->kobo->getUser());
+        if ($progression === null) {
+            return null;
+        }
+
+        return $progression >= 1.0;
+    }
+
+    private function createBookmark(?BookmarkUser $bookMark): array
+    {
+        if (!$bookMark instanceof BookmarkUser) {
+            return [];
+        }
+
+        $values = [
+            'Location' => [
+                'Type' => $bookMark->getLocationType(),
+                'Value' => $bookMark->getLocationValue(),
+                'Source' => $bookMark->getLocationSource(),
+            ],
+            'ProgressPercent' => $bookMark->getPercentAsInt(),
+            'ContentSourceProgressPercent' => $bookMark->getSourcePercentAsInt(),
+        ];
+
+        if (false === $bookMark->hasLocation()) {
+            unset($values['Location']);
+        }
+
+        return array_filter($values); // Remove null values
+    }
+
+    public function __toString(): string
+    {
+        return $this->serializer->serialize($this->createReadingState(), 'json', [DateTimeNormalizer::FORMAT_KEY => SyncResponse::DATE_FORMAT]);
+    }
+}

--- a/src/Kobo/Response/ReadingStateResponseFactory.php
+++ b/src/Kobo/Response/ReadingStateResponseFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Kobo\Response;
+
+use App\Entity\Book;
+use App\Entity\KoboDevice;
+use App\Kobo\SyncToken;
+use App\Service\BookProgressionService;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Inspired by https://github.com/janeczku/calibre-web/blob/master/cps/kobo.py
+ */
+class ReadingStateResponseFactory
+{
+    public function __construct(
+        protected MetadataResponseService $metadataResponseService,
+        protected BookProgressionService $bookProgressionService,
+        protected SerializerInterface $serializer)
+    {
+    }
+
+    public function create(SyncToken $syncToken, KoboDevice $kobo, Book $book): ReadingStateResponse
+    {
+        return new ReadingStateResponse(
+            $this->bookProgressionService,
+            $this->serializer,
+            $syncToken,
+            $kobo,
+            $book
+        );
+    }
+}

--- a/src/Kobo/Response/StateResponse.php
+++ b/src/Kobo/Response/StateResponse.php
@@ -26,6 +26,6 @@ class StateResponse extends JsonResponse
                     ],
                 ],
             ],
-        ], Response::HTTP_NO_CONTENT);
+        ], Response::HTTP_OK);
     }
 }

--- a/src/Kobo/Response/SyncResponseFactory.php
+++ b/src/Kobo/Response/SyncResponseFactory.php
@@ -17,8 +17,9 @@ class SyncResponseFactory
     public function __construct(
         protected MetadataResponseService $metadataResponseService,
         protected BookProgressionService $bookProgressionService,
-        protected SerializerInterface $serializer)
-    {
+        protected SerializerInterface $serializer,
+        protected ReadingStateResponseFactory $readingStateResponseFactory,
+    ) {
     }
 
     public function create(SyncToken $syncToken, KoboDevice $kobo): SyncResponse
@@ -28,7 +29,8 @@ class SyncResponseFactory
             $this->bookProgressionService,
             $syncToken,
             $kobo,
-            $this->serializer
+            $this->serializer,
+            $this->readingStateResponseFactory,
         );
     }
 

--- a/src/Kobo/Response/SyncResponseHelper.php
+++ b/src/Kobo/Response/SyncResponseHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Kobo\Response;
+
+use App\Entity\Book;
+use App\Entity\BookInteraction;
+use App\Entity\KoboDevice;
+use App\Kobo\SyncToken;
+
+// Inspired by https://github.com/janeczku/calibre-web/blob/master/cps/kobo.py
+
+/**
+ * @phpstan-type BookEntitlement array<string, mixed>
+ * @phpstan-type BookMetadata array<string, mixed>
+ * @phpstan-type BookReadingState array<string, mixed>
+ * @phpstan-type BookTag array<string, mixed>
+ */
+class SyncResponseHelper
+{
+    public function isChangedEntitlement(Book $book, KoboDevice $kobo, SyncToken $syncToken): bool
+    {
+        if ($this->isNewEntitlement($book, $syncToken)) {
+            return false;
+        }
+
+        if ($this->isChangedReadingState($book, $kobo, $syncToken)) {
+            return false;
+        }
+
+        return ($book->getUpdated() instanceof \DateTimeInterface
+            && $book->getUpdated() >= $syncToken->lastModified)
+            || $book->getCreated() >= $syncToken->lastCreated;
+    }
+
+    public function isNewEntitlement(Book $book, SyncToken $syncToken): bool
+    {
+        return $book->getKoboSyncedBook()->isEmpty() || $book->getCreated() < $syncToken->lastCreated;
+    }
+
+    public function isChangedReadingState(Book $book, KoboDevice $kobo, SyncToken $syncToken): bool
+    {
+        if ($this->isNewEntitlement($book, $syncToken)) {
+            return false;
+        }
+        $lastInteraction = $book->getLastInteraction($kobo->getUser());
+
+        return ($lastInteraction instanceof BookInteraction) && $lastInteraction->getUpdated() >= $syncToken->readingStateLastModified;
+    }
+}

--- a/src/Kobo/SyncToken.php
+++ b/src/Kobo/SyncToken.php
@@ -46,7 +46,7 @@ class SyncToken
 
     public function maxLastModified(?\DateTimeInterface ...$value): ?\DateTimeInterface
     {
-        return $this->max(
+        return self::max(
             $this->lastModified,
             ...$value
         );
@@ -54,13 +54,13 @@ class SyncToken
 
     public function maxLastCreated(?\DateTimeInterface ...$value): ?\DateTimeInterface
     {
-        return $this->max(
+        return self::max(
             $this->lastCreated,
             ...$value
         );
     }
 
-    protected function max(?\DateTimeInterface ...$dates): ?\DateTimeInterface
+    protected static function max(?\DateTimeInterface ...$dates): ?\DateTimeInterface
     {
         $max = null;
         foreach ($dates as $date) {

--- a/src/Repository/KoboDeviceRepository.php
+++ b/src/Repository/KoboDeviceRepository.php
@@ -50,4 +50,10 @@ class KoboDeviceRepository extends ServiceEntityRepository
 
         return $result;
     }
+
+    public function save(KoboDevice $kobo): void
+    {
+        $this->_em->persist($kobo);
+        $this->_em->flush();
+    }
 }

--- a/templates/kobodevice_user/index.html.twig
+++ b/templates/kobodevice_user/index.html.twig
@@ -14,7 +14,11 @@
         <tbody>
         {% for kobo in kobos %}
             <tr>
-                <td>{{ kobo.name }}</td>
+                <td>{{ kobo.name }}
+                {% if kobo.model is not empty %}
+                   <br /><small class="text-muted">{{ kobo.model }}</small>
+                {% endif %}
+                </td>
                 <td>{{ kobo.accessKey }}</td>
                 <td>
                     {% if is_granted('EDIT', kobo) %}

--- a/templates/kobodevice_user/instructions.html.twig
+++ b/templates/kobodevice_user/instructions.html.twig
@@ -8,6 +8,7 @@
             <li>Edit the file with a text editor (vs-code, vim, etc).</li>
             <li>
                 Alter the line <code>api_endpoint</code> under the section <code>[OneStoreServices]</code> (or create it if it doesn't exist). <br>
+                Make sure to replace the <code>reading_services_host</code> if it exists, to avoid loosing your reading progression. <br>
                 You can also edit the <code>image_host</code> and <code>image_url_quality_template</code> entries.
                 <pre>
                     {% apply spaceless -%}
@@ -23,6 +24,7 @@
                         {{- "\n" }}image_host={{ app.request.getUriForPath("") -}}
                         {{- "\n" }}image_url_quality_template={{ url('koboapi_endpoint', {'accessKey': token}) ~ '/image/{ImageId}/{width}/{height}/{Quality}/isGreyscale/image.jpg' -}}
                     {% endif %}
+                        {{- "\n" }}reading_services_host={{ app.request.getUriForPath("") -}}
                         {{- "\n"}}...
                     </code>
                     {%- endapply %}

--- a/tests/Controller/Kobo/KoboAnalyticsControllerTest.php
+++ b/tests/Controller/Kobo/KoboAnalyticsControllerTest.php
@@ -3,9 +3,13 @@
 namespace App\Tests\Controller\Kobo;
 
 
+use App\Entity\KoboDevice;
+
 class KoboAnalyticsControllerTest extends AbstractKoboControllerTest
 {
     const SERIAL_NUMBER = 'N9413679432456';
+    const DEVICE_ID = '2a92bba197b1e0574a3f7d29cb2b05b399ab0d197e6b1aa230bfb75a920b14e7c';
+    const MODEL = 'Kobo Libra H2O';
     const APP_VERSION = '4.38.21908';
 
     public function testPostEvent(): void
@@ -442,9 +446,18 @@ class KoboAnalyticsControllerTest extends AbstractKoboControllerTest
         ];
         $client = static::getClient();
         $client?->setServerParameter('HTTP_CONNECTION', 'keep-alive');
+        $server = [
+            'HTTP_'.KoboDevice::KOBO_DEVICE_ID_HEADER => self::DEVICE_ID,
+            'HTTP_'.KoboDevice::KOBO_DEVICE_MODEL => self::MODEL,
+        ];
         $client?->request('POST', '/kobo/'.$this->accessKey.'/v1/analytics/event', [
             'json' => $body,
-        ]);
+        ], [], $server);
+
+        // Make sure we define Kobo's device_id and model
+        $kobo =  $this->getKoboDevice(true);
+        self::assertSame(self::DEVICE_ID,$kobo->getDeviceId());
+        self::assertSame(self::MODEL,$kobo->getModel());
 
         self::assertResponseIsSuccessful();
         self::assertResponseHeaderSame('Connection', 'keep-alive');

--- a/tests/Controller/Kobo/ReadServiceCheckForChangesControllerTest.php
+++ b/tests/Controller/Kobo/ReadServiceCheckForChangesControllerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Tests\Controller\Kobo;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ReadServiceCheckForChangesControllerTest extends AbstractKoboControllerTest
+{
+    public function testCheckForChangesPost() : void
+    {
+        $client = static::getClient();
+
+        $client?->request('POST', '/api/v3/content/checkforchanges');
+        self::assertResponseIsSuccessful();
+
+        /** @var Response|null $response */
+        $response = $client?->getResponse();
+
+        $responseContent = $response?->getContent();
+        self::assertSame('[]', $responseContent);
+    }
+}


### PR DESCRIPTION
1. Read a book on the Kobo
2. Leave the book
3. Reopen the book

Expected result:
You are on the same page as before


Current result:
You are the beginning of the last chapter.


====

Analysis:
When reading a book a request to `PUT /v1/library/{uuid}/state` is pushed with the progression.
When opening a book, a request to `GET /v1/library/{uuid}/state` is done to read the  progression (once the book is opened)

I was sure that it was linked to the sync process, but this behavior happen without sync.
I tried to compare the request with the real store, and fixed a few things, however it is still not working.

For me, it's likely linked to date&time issue with one of the field. Or it's linked to an external service such as https://readingservices.kobo.com. I don't know yet.

```
Nov  8 14:01:49 nickel: (  9102.142 @ 0x33f8130 / sync.debug) virtual void RequestBookmarkCommand::authenticatedExecute() 
Nov  8 14:01:49 nickel: (  9102.143 @ 0x33f8130 / packetdump.debug) Making Onestore request: "https://<domain>/v1/library/427f40f0-3095-4d57-92e1-313b84bd7e82/state" 
Nov  8 14:01:49 nickel: (  9102.148 @ 0x33f8130 / packetdump.debug) "" 
Nov  8 14:01:49 nickel: (  9102.149 @ 0x33f8130 / headerdump.debug) "Accept-Encoding" = "gzip" 
Nov  8 14:01:49 nickel: (  9102.150 @ 0x33f8130 / headerdump.debug) "Accept" = "application/json" 
Nov  8 14:01:49 nickel: (  9102.150 @ 0x33f8130 / headerdump.debug) "Authorization" = "Bearer ..." 
Nov  8 14:01:49 nickel: (  9102.151 @ 0x33f8130 / headerdump.debug) "Content-Type" = "application/json" 

Nov  8 14:01:49 nickel: (  9102.160 @ 0x33f8130 / headerdump.debug) "User-Agent" = "Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0384/4.38.23038)" 
Nov  8 14:01:49 nickel: (  9102.161 @ 0x33f8130 / headerdump.debug) "Accept-Language" = "en-US, *;q=0.9" 
Nov  8 14:01:49 nickel: (  9102.161 @ 0x33f8130 / headerdump.debug) "Host" = "<domain>" 
Nov  8 14:01:49 nickel: (  9102.163 @ 0x33f8130 / packetdump.debug) -------------------------- REQUEST --------------------------- 
Nov  8 14:01:49 nickel: (  9102.163 @ 0x33f8130 / packetdump.debug) "GET" > To:  "https://<domain>/v1/library/427f40f0-3095-4d57-92e1-313b84bd7e82/state" 
Nov  8 14:01:49 nickel: (  9102.164 @ 0x33f8130 / packetdump.debug)     ---------------------- HEADERS --------------------------- 
Nov  8 14:01:49 nickel: (  9102.171 @ 0x33f8130 / packetdump.debug) "Accept-Encoding" : "gzip" 
Nov  8 14:01:49 nickel: (  9102.172 @ 0x33f8130 / packetdump.debug) "Accept" : "application/json" 
Nov  8 14:01:49 nickel: (  9102.174 @ 0x33f8130 / packetdump.debug) "Authorization" : "Bearer ..." 
Nov  8 14:01:49 nickel: (  9102.174 @ 0x33f8130 / packetdump.debug) "Content-Type" : "application/json" 
Nov  8 14:01:49 nickel: (  9102.181 @ 0x33f8130 / packetdump.debug) "User-Agent" : "Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0384/4.38.23038)" 
Nov  8 14:01:49 nickel: (  9102.181 @ 0x33f8130 / packetdump.debug) "Accept-Language" : "en-US, *;q=0.9" 
Nov  8 14:01:49 nickel: (  9102.182 @ 0x33f8130 / packetdump.debug) "Host" : "<domain>" 
Nov  8 14:01:49 nickel: (  9102.182 @ 0x33f8130 / packetdump.debug)     ---------------------- BODY --------------------------- 
Nov  8 14:01:49 nickel: (  9102.182 @ 0x33f8130 / packetdump.debug) "" 
Nov  8 14:01:49 nickel: (  9102.182 @ 0x33f8130 / packetdump.debug) -------------------------- END OF REQUEST --------------------------- 
Nov  8 14:01:49 nickel: (  9102.262 @ 0x26ea160 / packetdump.debug) void GoogleAnalyticsRequester::sendRequest(const QUrl&)  QUrl( "https://ssl.google-analytics.com/collect?v=1&tid=UA-6177406-38&cid=4345b396-a57b-4279-bf73-be0f88ec5473&av=4.38.23038&an=nickel&sr=1264x1680&ul=en-us&cd60=ReadingView&cd64=application/x-kobo-epub+zip&cd65=Paid&cd72=application/x-kobo-epub+zip&t=event&ec=ReadingExperience&ea=OpenContent&el=application/x-kobo-epub+zip" )  
Nov  8 14:01:49 nickel: (  9102.262 @ 0x26ea160 / headerdump.debug) "User-Agent" = "Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0384/4.38.23038)" 
Nov  8 14:01:49 nickel: (  9102.263 @ 0x26ea160 / headerdump.debug) "Accept-Language" = "en-US, *;q=0.9" 
Nov  8 14:01:49 nickel: (  9102.263 @ 0x26ea160 / headerdump.debug) "Host" = "ssl.google-analytics.com" 
Nov  8 14:01:49 nickel: (  9102.682 @ 0x33f8130 / packetdump.warning) "https://<domain>/v1/library/427f40f0-3095-4d57-92e1-313b84bd7e82/state" => "Error downloading https://<domain>/v1/library/427f40f0-3095-4d57-92e1-313b84bd7e82/state - server replied: Not Implemented" 
Nov  8 14:01:49 nickel: (  9102.684 @ 0x33f8130 / packetdump.warning) HTTP Status Code: 501 
Nov  8 14:01:49 nickel: (  9102.685 @ 0x33f8130 / packetdump.warning) Error: 301 
Nov  8 14:01:49 nickel: (  9102.685 @ 0x33f8130 / packetdump.warning) Source: "https://<domain>/v1/library/427f40f0-3095-4d57-92e1-313b84bd7e82/state" 
Nov  8 14:01:49 nickel: (  9102.686 @ 0x33f8130 / packetdump.warning) "[]" 
Nov  8 14:01:49 nickel: (  9102.688 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.689 @ 0x33f8130 / sync.debug)  ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.690 @ 0x33f8130 / sync.debug)  [ UpdateAnnotationsCommand(0x2a47e30) ] 
Nov  8 14:01:49 nickel: (  9102.691 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.692 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.694 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.695 @ 0x33f8130 / sync.debug)  ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.696 @ 0x33f8130 / sync.debug)  [ UpdateAnnotationsCommand(0x2a47e30) ] 
Nov  8 14:01:49 nickel: (  9102.697 @ 0x33f8130 / sync.debug)  [ UpdateAttachmentsCommand(0x3145ef0) ] 
Nov  8 14:01:49 nickel: (  9102.697 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.698 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.699 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.700 @ 0x33f8130 / sync.debug)  ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.701 @ 0x33f8130 / sync.debug)  [ UpdateAnnotationsCommand(0x2a47e30) ] 
Nov  8 14:01:49 nickel: (  9102.702 @ 0x33f8130 / sync.debug)  [ UpdateAttachmentsCommand(0x3145ef0) ] 
Nov  8 14:01:49 nickel: (  9102.703 @ 0x33f8130 / sync.debug)  [ GetUpdatedAnnotationsCommand(0x3875a50) ] 
Nov  8 14:01:49 nickel: (  9102.703 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.703 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.703 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.704 @ 0x33f8130 / sync.debug)  ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.704 @ 0x33f8130 / sync.debug)  [ UpdateAnnotationsCommand(0x2a47e30) ] 
Nov  8 14:01:49 nickel: (  9102.704 @ 0x33f8130 / sync.debug)  [ UpdateAttachmentsCommand(0x3145ef0) ] 
Nov  8 14:01:49 nickel: (  9102.704 @ 0x33f8130 / sync.debug)  [ GetUpdatedAnnotationsCommand(0x3875a50) ] 
Nov  8 14:01:49 nickel: (  9102.705 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.705 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.705 @ 0x33f8130 / sync.debug) pumping with 3 pending commands and 0 active commands 
Nov  8 14:01:49 nickel: (  9102.705 @ 0x33f8130 / sync.debug) executing UpdateAnnotationsCommand(0x2a47e30) 
Nov  8 14:01:49 nickel: (  9102.705 @ 0x33f8130 / sync.debug) virtual void OAuthAuthenticatedCommand::execute() 
Nov  8 14:01:49 nickel: (  9102.715 @ 0x33f8130 / sync.debug) UpdateAnnotationsCommand(0x2a47e30) finished 
Nov  8 14:01:49 nickel: (  9102.716 @ 0x33f8130 / sync.debug) RequestBookmarkCommand(0x3b795e0) finished 
Nov  8 14:01:49 nickel: (  9102.716 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.717 @ 0x33f8130 / sync.debug)  ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.717 @ 0x33f8130 / sync.debug)  [ UpdateAttachmentsCommand(0x3145ef0) ] 
Nov  8 14:01:49 nickel: (  9102.717 @ 0x33f8130 / sync.debug)  [ GetUpdatedAnnotationsCommand(0x3875a50) ] 
Nov  8 14:01:49 nickel: (  9102.717 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.717 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.718 @ 0x33f8130 / sync.debug) pumping with 2 pending commands and 0 active commands 
Nov  8 14:01:49 nickel: (  9102.718 @ 0x33f8130 / sync.debug) executing UpdateAttachmentsCommand(0x3145ef0) 
Nov  8 14:01:49 nickel: (  9102.718 @ 0x33f8130 / sync.debug) virtual void OAuthAuthenticatedCommand::execute() 
Nov  8 14:01:49 nickel: (  9102.720 @ 0x33f8130 / sync.debug) UpdateAttachmentsCommand(0x3145ef0) finished 
Nov  8 14:01:49 nickel: (  9102.720 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.721 @ 0x33f8130 / sync.debug)  ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.721 @ 0x33f8130 / sync.debug)  [ GetUpdatedAnnotationsCommand(0x3875a50) ] 
Nov  8 14:01:49 nickel: (  9102.721 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.722 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.722 @ 0x33f8130 / sync.debug) pumping with 1 pending commands and 0 active commands 
Nov  8 14:01:49 nickel: (  9102.722 @ 0x33f8130 / sync.debug) executing GetUpdatedAnnotationsCommand(0x3875a50) 
Nov  8 14:01:49 nickel: (  9102.722 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.723 @ 0x33f8130 / sync.debug)  ----- Running ------ 
Nov  8 14:01:49 nickel: (  9102.723 @ 0x33f8130 / sync.debug)  [ GetUpdatedAnnotationsCommand(0x3875a50) ] 
Nov  8 14:01:49 nickel: (  9102.723 @ 0x33f8130 / sync.debug)    ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.723 @ 0x33f8130 / sync.debug)    [ CheckForAnnotationChangesCommand(0x30245a0) ] 
Nov  8 14:01:49 nickel: (  9102.724 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.726 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.726 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:49 nickel: (  9102.726 @ 0x33f8130 / sync.debug)  ----- Running ------ 
Nov  8 14:01:49 nickel: (  9102.727 @ 0x33f8130 / sync.debug)  [ GetUpdatedAnnotationsCommand(0x3875a50) ] 
Nov  8 14:01:49 nickel: (  9102.727 @ 0x33f8130 / sync.debug)    ----- Queued ------- 
Nov  8 14:01:49 nickel: (  9102.727 @ 0x33f8130 / sync.debug)    [ CheckForAnnotationChangesCommand(0x30245a0) ] 
Nov  8 14:01:49 nickel: (  9102.727 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:49 nickel: (  9102.728 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:49 nickel: (  9102.728 @ 0x33f8130 / sync.debug) pumping with 1 pending commands and 0 active commands 
Nov  8 14:01:49 nickel: (  9102.728 @ 0x33f8130 / sync.debug) executing CheckForAnnotationChangesCommand(0x30245a0) 
Nov  8 14:01:49 nickel: (  9102.728 @ 0x33f8130 / sync.debug) virtual void OAuthAuthenticatedCommand::execute() 
Nov  8 14:01:49 nickel: (  9102.729 @ 0x33f8130 / headerdump.debug) "Accept-Encoding" = "gzip" 
Nov  8 14:01:49 nickel: (  9102.730 @ 0x33f8130 / headerdump.debug) "Accept" = "application/json" 
Nov  8 14:01:49 nickel: (  9102.730 @ 0x33f8130 / headerdump.debug) "Authorization" = "Bearer ..." 


Nov  8 14:01:49 nickel: (  9102.734 @ 0x33f8130 / headerdump.debug) "Host" = "readingservices.kobo.com" 
Nov  8 14:01:49 nickel: (  9102.735 @ 0x33f8130 / packetdump.debug) -------------------------- REQUEST --------------------------- 
Nov  8 14:01:49 nickel: (  9102.735 @ 0x33f8130 / packetdump.debug) "POST" > To:  "https://readingservices.kobo.com/api/v3/content/checkforchanges" 
Nov  8 14:01:49 nickel: (  9102.735 @ 0x33f8130 / packetdump.debug)     ---------------------- HEADERS --------------------------- 
Nov  8 14:01:49 nickel: (  9102.736 @ 0x33f8130 / packetdump.debug) "Accept-Encoding" : "gzip" 
Nov  8 14:01:49 nickel: (  9102.736 @ 0x33f8130 / packetdump.debug) "Accept" : "application/json" 
Nov  8 14:01:49 nickel: (  9102.736 @ 0x33f8130 / packetdump.debug) "Authorization" : "Bearer ...." 
Nov  8 14:01:49 nickel: (  9102.736 @ 0x33f8130 / packetdump.debug) "Content-Type" : "application/json" 

Nov  8 14:01:49 nickel: (  9102.738 @ 0x33f8130 / packetdump.debug) "User-Agent" : "Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0384/4.38.23038)" 
Nov  8 14:01:49 nickel: (  9102.738 @ 0x33f8130 / packetdump.debug) "Accept-Language" : "en-US, *;q=0.9" 
Nov  8 14:01:49 nickel: (  9102.739 @ 0x33f8130 / packetdump.debug) "Host" : "readingservices.kobo.com" 
Nov  8 14:01:49 nickel: (  9102.739 @ 0x33f8130 / packetdump.debug) "Content-Length" : "73" 
Nov  8 14:01:49 nickel: (  9102.739 @ 0x33f8130 / packetdump.debug)     ---------------------- BODY --------------------------- 
Nov  8 14:01:49 nickel: (  9102.739 @ 0x33f8130 / packetdump.debug) "[{"ContentId": "427f40f0-3095-4d57-92e1-313b84bd7e82","etag": "W/\"0\""}]" 
Nov  8 14:01:49 nickel: (  9102.740 @ 0x33f8130 / packetdump.debug) -------------------------- END OF REQUEST --------------------------- 
Nov  8 14:01:50 nickel: (  9102.989 @ 0x33f8130 / packetdump.debug) ================== RESPONSE ============================= 
Nov  8 14:01:50 nickel: (  9102.990 @ 0x33f8130 / packetdump.debug) URL: "https://readingservices.kobo.com/api/v3/content/checkforchanges" 
Nov  8 14:01:50 nickel: (  9102.991 @ 0x33f8130 / packetdump.debug) HTTP Status Code: 200 
Nov  8 14:01:50 nickel: (  9102.992 @ 0x33f8130 / packetdump.debug) Is Cached?: false 
Nov  8 14:01:50 nickel: (  9102.993 @ 0x33f8130 / packetdump.debug) "Date" : "Fri, 08 Nov 2024 13:01:50 GMT" 
Nov  8 14:01:50 nickel: (  9102.994 @ 0x33f8130 / packetdump.debug) "Content-Type" : "application/json; charset=utf-8" 
Nov  8 14:01:50 nickel: (  9102.994 @ 0x33f8130 / packetdump.debug) "Content-Length" : "2" 
Nov  8 14:01:50 nickel: (  9102.995 @ 0x33f8130 / packetdump.debug) "Connection" : "keep-alive" 
Nov  8 14:01:50 nickel: (  9102.996 @ 0x33f8130 / packetdump.debug) "CF-Cache-Status" : "DYNAMIC" 
Nov  8 14:01:50 nickel: (  9102.997 @ 0x33f8130 / packetdump.debug) "Set-Cookie" : .... expires=Fri, 08-Nov-24 13:31:50 GMT; domain=.kobo.com; HttpOnly; Secure; SameSite=None" 
Nov  8 14:01:50 nickel: (  9102.997 @ 0x33f8130 / packetdump.debug) "Server" : "cloudflare" 
Nov  8 14:01:50 nickel: (  9102.998 @ 0x33f8130 / packetdump.debug) "CF-RAY" : "8df5c1082b71bc59-ZRH" 
Nov  8 14:01:50 nickel: (  9103.000 @ 0x33f8130 / packetdump.debug) ========================================================= 
Nov  8 14:01:50 nickel: (  9103.000 @ 0x33f8130 / packetdump.debug) "[ ] " 
Nov  8 14:01:50 nickel: (  9103.002 @ 0x33f8130 / sync.debug) CheckForAnnotationChangesCommand(0x30245a0) finished 
Nov  8 14:01:50 nickel: (  9103.002 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:50 nickel: (  9103.002 @ 0x33f8130 / sync.debug)  ----- Running ------ 
Nov  8 14:01:50 nickel: (  9103.003 @ 0x33f8130 / sync.debug)  [ GetUpdatedAnnotationsCommand(0x3875a50) ] 
Nov  8 14:01:50 nickel: (  9103.003 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:50 nickel: (  9103.003 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:50 nickel: (  9103.003 @ 0x33f8130 / sync.debug) pumping with 0 pending commands and 0 active commands 
Nov  8 14:01:50 nickel: (  9103.003 @ 0x33f8130 / sync.debug) GetUpdatedAnnotationsCommand(0x3875a50) finished 
Nov  8 14:01:50 nickel: (  9103.004 @ 0x33f8130 / sync.debug) =================== SYNC QUEUE [ SyncAnnotationsCommandV2(0x29cd178) ] ==================== 
Nov  8 14:01:50 nickel: (  9103.005 @ 0x33f8130 / sync.debug) =================================================== 
Nov  8 14:01:50 nickel: (  9103.005 @ 0x33f8130 / sync.debug)    
Nov  8 14:01:50 nickel: (  9103.005 @ 0x33f8130 / sync.debug) pumping with 0 pending commands and 0 active commands 
Nov  8 14:01:50 nickel: (  9103.005 @ 0x33f8130 / sync.debug) SyncAnnotationsCommandV2(0x29cd178) finished 
Nov  8 14:01:54 nickel: (  9107.603 @ 0x26ea160 / packetdump.debug) void GoogleAnalyticsRequester::sendRequest(const QUrl&)  QUrl( "https://ssl.google-analytics.com/g/collect?v=2&tid=G-HKVPYM8786&cid=4345b396-a57b-4279-bf73-be0f88ec5473&_et=1&_z=ccd.v9b&sr=1264x1680&ul=en-us&ep.book_format=KOBO_EPUB&ep.book_id=427f40f0-3095-4d57-92e1-313b84bd7e82&ep.book_type=Unlocked&ep.orientation=Portrait&en=open_content&ec=ReadingExperience" )  
Nov  8 14:01:54 nickel: (  9107.604 @ 0x26ea160 / headerdump.debug) "User-Agent" = "Mozilla/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit/538.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/538.1 (Kobo Touch 0384/4.38.23038)" 
Nov  8 14:01:54 nickel: (  9107.604 @ 0x26ea160 / headerdump.debug) "Accept-Language" = "en-US, *;q=0.9" 
Nov  8 14:01:54 nickel: (  9107.605 @ 0x26ea160 / headerdump.debug) "Host" = "ssl.google-analytics.com" 
```